### PR TITLE
[FIX] 앨범뷰 수록곡 목록이 조회되지 않는 문제를 해결

### DIFF
--- a/app/src/main/java/org/sopt/jointseminar/melon/data/entity/album/AlbumSongInfo.kt
+++ b/app/src/main/java/org/sopt/jointseminar/melon/data/entity/album/AlbumSongInfo.kt
@@ -1,6 +1,9 @@
 package org.sopt.jointseminar.melon.data.entity.album
 
+import com.google.gson.annotations.SerializedName
+
 data class AlbumSongInfo(
     val number: Int,
+    @SerializedName("singname")
     val title: String,
 )

--- a/app/src/main/res/layout/fragment_album.xml
+++ b/app/src/main/res/layout/fragment_album.xml
@@ -391,6 +391,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="3dp"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintTop_toBottomOf="@id/btn_select_all"
                     tools:itemCount="1"
                     tools:listitem="@layout/item_music_horizontal" />


### PR DESCRIPTION
## 변경 사항 😉
1. 서버에서 전달해주는 body값이 수정됨에 따라 `AlbumSongInfo` 데이터 클래스에서 `title` 프로퍼티에 **@SerializedName("singname") 추가**
2. 수록곡 리스트 리사이클러뷰가 보이지 않는 문제를 해결
   - 원인 : 기존 RecyclerView에 LayoutManager 속성을 지정해주지 않아 수록곡 목록이 보이지 않았음
   - 해결 : `app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"`추가
   - 아래 사진에서 표시한 부분처럼 수록곡 목록 등장 !!!
   
<br>

## 스크린샷 🖼
<img width="240" alt="스크린샷 2022-06-03 오후 4 00 39" src="https://user-images.githubusercontent.com/48701368/171803998-9f61b33d-b276-430f-a10b-0a6bcb41c64e.png">

